### PR TITLE
WMCO Upgrade enhancement design update

### DIFF
--- a/enhancements/authentication/allow-users-to-manage-their-own-tokens.md
+++ b/enhancements/authentication/allow-users-to-manage-their-own-tokens.md
@@ -1,0 +1,202 @@
+---
+title: allow-users-to-manage-their-own-tokens
+authors:
+  - "@stlaz"
+reviewers:
+  - "@sttts"
+  - "@deads2k"
+  - "@marun"
+  - "@vareti"
+approvers:
+  - "@sttts"
+  - "@deads2k"
+creation-date: 2020-10-22
+last-updated: 2020-10-22
+status: implementable
+see-also:
+- [enhancement: Secure OAuth Resource Storage](https://github.com/openshift/enhancements/pull/323)
+replaces:
+superseded-by:
+
+---
+
+# Allow Users To Manage Their Own Tokens
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [x] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
+
+## Summary
+
+This enhancement describes how to allow OpenShift users to be able to list their
+access tokens so that they can easily delete an access token specific to an
+application, all of their tokens, a token from the past they no longer need etc.
+
+## Motivation
+
+It is quite easy for users to retrieve tokens but it is also not so hard
+for them to be able to lose access to them - people don't usually search
+their cookies for the value of the token, or don't keep history of the
+tokens they retrieve by issuing the `oc login` command multiple times.
+
+### Goals
+
+Allow users to (using either console/CLI):
+- list their own tokens
+- view details of a specific token
+- delete their own tokens
+
+### Non-Goals
+
+- Changing the granularity of tokens to sessions: tokens can be used by many sessions.
+  The oauth system is not aware of sessions and won't be with this enhancement.
+
+## Proposal
+
+### User Stories [optional]
+
+#### Story 1
+A user is able to list/watch and delete (in both CLI and the web console) all of
+the tokens that were issued on their behalf.
+
+#### Story 2
+The user can look for specific details of their token like the name of the OAuth2
+client that requested issuing the token, token scopes, token expiration date etc.,
+making it easier for them to  audit their accesses.
+
+### Implementation Details/Notes/Constraints [optional]
+
+The OAuth API server gets a new API endpoint - `useroauthaccesstokens`. This endpoint
+allows to `get`, `list`, `watch` and `delete` tokens that belong to the current user.
+The user is determined based on the context of the request, as supplied by the generic
+API server logic. This keeps impersonation working, so a user impersonating another
+one is capable to perform the above actions on behalf of the impersonated user.
+
+Upon receiving a REST request to the new endpoint, the API server internally
+wires the get/list/watch/delete requests to the `oauthaccesstoken` API endpoint.
+It then converts the results and returns them as `useroauthaccesstoken` type.
+The schema of the `useroauthaccesstoken` type is the same as of `oauthaccesstoken`,
+they only differ in kind.
+
+To list/watch the tokens internally, a field selector of the form `userName=<userName>`
+is used. It is wrapped in an and-type of a selector around any field selector
+user specifies.
+
+When getting or deleting a token, there must be an exact match of `token.userName`
+and the `userName` retrieved as described above. If such a match does not occur,
+the API server must return "404 - Not Found" so that it is not possible to guess
+other people's token object names.
+
+#### Roles modifications
+
+The `basic-user` clusterrole should now additionally receive the following rule:
+```
+apiGroups:
+- oauth.openshift.io
+resources:
+- useroauthaccesstokens
+verbs:
+- get
+- list
+- watch
+- delete
+```
+
+Since the new API allows to remove user-owned access tokens, it should no longer
+be necessary to keep the `system:oauth-token-deleter` clusterrole bound to the
+`system:authenticated` group. On the contrary, the currently existing clusterrole
+binding means a remaining, small security hole where a user can delete tokens
+that he only knows the sha256 hash of (but it cannot be used to login). To address
+this security hole, the clusterrolebinding `system:oauth-token-deleters` will
+therefore get deprecated as described in
+[Graduation Criteria - Removing a Deprecated Feature](#graduation-criteria---removing-a-deprecated-feature).
+
+#### Default table view in CLI
+
+By default, the following fields will be displayed when listing tokens in the
+command line:
+
+- metadata.name (`NAME`)
+- clientName (`CLIENT NAME`)
+- metadata.creationTimestamp (`CREATED`)
+- expiresIn (`EXPIRES`)
+- redirectURI (`REDIRECT URI`)
+- scopes (`SCOPES`)
+
+This matches the fields displayed for the `OAuthAccessToken` resource type.
+
+### Risks and Mitigations
+
+The proposal describes changes to a security sensitive resource that serves
+as a means to authenticate to OpenShift.
+
+The level of confidentiality of the `OAuthAccessToken` objects was lowered in
+https://github.com/openshift/enhancements/pull/323 and therefore, should a
+token leak, it is no longer possible to use the name of such an object to
+log in as a different user. On the other hand, the token still contains
+information about the user and which services they might be accessing, and
+with in the current RBAC rules, it would also allow a malicious user to
+remove the token of the victim.
+
+The above risks should be considered during implementation reviews and when
+setting up testing for this feature.
+
+## Design Details
+
+### Graduation Criteria - Removing a Deprecated Feature
+
+Versions: 4.n is the version where the feature gets released, 4.n+1 is the major version succeeding 4.n
+
+In 4.n, the release notes must mention the deprecation of the `system:oauth-token-deleters`
+clusterrolebinding and its removal in 4.n+1. This is going to happen in favour of having to
+specifically bind the `system:oauth-token-deleter` clusterrole to the subject that needs to
+be able to remove oauthaccesstokens directly. Any other self-management of tokens (even
+when impersonated) should happen by using the new `useroauthaccesstoken` API.
+
+In 4.n+1, the `system:oauth-token-deleters` clusterrolebinding will be deleted
+from the platform.
+
+### Test Plan
+
+New e2e tests:
+1. using the new endpoint, a user can get/list/watch/delete all of the tokens that were issued to them
+2. a user cannot get/list/watch/delete tokens for any other user
+3. user cannot create, update, patch tokens, neither his own, nor of other users.
+4. non-sha256 tokens are not returned by any of the new endpoints.
+
+#### Examples
+
+Without changes to the CLI code, the following will be possible:
+```
+$ oc get useroauthaccesstokens
+$ oc get -w useroauthaccesstokens
+$ oc get useroauthaccesstokens <token-name> [output options]
+$ oc delete useroauthaccesstokens <user-owned-token-name>
+```
+
+## Implementation History
+
+Major milestones in the life cycle of a proposal should be tracked in `Implementation
+History`.
+
+## Drawbacks
+
+The idea is to find the best form of an argument why this enhancement should _not_ be implemented.
+
+## Alternatives
+
+Similar to the `Drawbacks` section the `Alternatives` section is used to
+highlight and record other possible approaches to delivering the value proposed
+by an enhancement.
+
+## Infrastructure Needed [optional]
+
+Use this section if you need things from the project. Examples include a new
+subproject, repos requested, github details, and/or testing infrastructure.
+
+Listing these here allows the community to get the process for these resources
+started right away.

--- a/enhancements/storage/csi-vsphere-operator.md
+++ b/enhancements/storage/csi-vsphere-operator.md
@@ -1,0 +1,75 @@
+---
+title: csi-ebs-operator
+authors:
+  - "@gnufied"
+reviewers:
+  - "@jsafrane”
+  - "@fbertina"
+  - "@chuffman"
+approvers:
+  - "@..."
+creation-date: 2020-10-05
+last-updated: 2020-10-05
+status: implementable
+see-also: https://github.com/openshift/enhancements/blob/master/enhancements/storage/csi-driver-install.md
+replaces:
+superseded-by:
+---
+
+# CSI Driver operator for vSphere
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [ ] Design details are appropriately documented from clear requirements
+- [ ] Test plan is defined
+- [ ] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in [openshift-docs](https://github.com/openshift/openshift-docs/)
+
+## Summary
+
+This enhancement proposes deployment of vSphere CSI driver on Openshift as a default component.
+
+## Motivation
+
+* vSphere is a key cloud provider for OpenShift and is supported in Openshift 3.x and 4.x. We need it to be supported and available even if in-tree drivers have been removed.
+* vSphere CSI driver provides new features such as - volume expansion, snapshotting and cloning which were previously unavailable with intree driver.
+
+### Goals
+
+* Create an operator to install the vSphere CSI driver.
+* Publish the driver and operator via default OCP build pipeline.
+* Enable creation of vSphere CSI storageclass, so as OCP users can start consuming vSphere CSI volumes without requiring further configuration.
+
+### Non-Goals
+
+* We don't intend to create a brand new driver with this KEP but merely want to deploy and configure upstream vSphere CSI driver - https://github.com/kubernetes-sigs/vsphere-csi-driver/
+
+
+## Proposal
+
+OCP ships with a vsphere-csi-driver-operator by default which is managed by [cluster-storage-operator](https://github.com/openshift/cluster-storage-operator/).
+vSphere CSI driver has few dependencies on installer though and they are:
+
+### Installer dependency
+
+* vSphere CSI driver requires HW version 15 on VMs that make up OCP cluster. Currently the rhcos OVA file Red Hat ships has default HW version configured to 13 and hence VM version should be updated.
+* Configuration of vSphere StorageClass requires knowledge of storage policy that was created in vCenter. Without this information - it is not possible to create a working storageClass for CSI driver.
+
+#### HW version of OCP VMs
+
+As mentioned above - vSphere CSI driver requires HW version 15 on all the VMs that make OCP cluster. Since, Openshift defaults to HW version 13 when a vSphere OCP cluster gets created - vSphere CSI driver isn't workable on the OCP cluster by default.
+
+To solve this following alternatives were considered:
+
+* We could provide manual instructions to the user about updating hardware version of their VMs. This won't be automatic but in some cases not even possible because some existing VMs can't be upgraded to HW version 15 in-place.
+* We could update installer to set HW version 15 - when appropriate hypervisor version(6.7u3 or higher) is detected.
+* For UPI install - we can additionally document required HW version while creating VMs.
+
+#### StoragePolicy configuration
+
+Currently while deploying Openshift a user can configure datastore used by OCP via install-config.yaml. vSphere CSI driver however can't use datastore directly and must be configured with vSphere storage policy. This can be done by an optional field in `Infrastructure` type of installer and if populated vsphere CSI driver operator will create storageClass with selected vSphere storage policy.
+
+### Deployment strategy
+
+vSphere CSI driver operator will be deployed by [cluster-storage-operator](https://github.com/openshift/cluster-storage-operator/)

--- a/enhancements/storage/csi-vsphere-operator.md
+++ b/enhancements/storage/csi-vsphere-operator.md
@@ -48,7 +48,7 @@ This enhancement proposes deployment of vSphere CSI driver on Openshift as a def
 
 ## Proposal
 
-OCP ships with a vsphere-csi-driver-operator by default which is managed by [cluster-storage-operator](https://github.com/openshift/cluster-storage-operator/).
+OCP ships with a vmware-vsphere-csi-driver-operator by default which is managed by [cluster-storage-operator](https://github.com/openshift/cluster-storage-operator/).
 vSphere CSI driver has few dependencies on installer though and they are:
 
 ### Installer dependency
@@ -81,7 +81,7 @@ The cluster-storage-operator will deploy all the resources necessary for creatin
 5. A instance of `ClusterCSIDriver` will be created to faciliate managment of driver operator.  `ClusterCSIDriver` is already defined in - https://github.com/openshift/api/blob/master/operator/v1/types_csi_cluster_driver.go but needs to be expanded to include vSphere CSI driver.
 6. cluster-storage-operator will request CVO to create required cloud-credentials for talking with vCenter API.
 
-#### Driver deployment via vsphere-csi-driver-operator.
+#### Driver deployment via vmware-vsphere-csi-driver-operator.
 
 The operator itself will be responsible for running the driver and all the required sidecars (attacher, provisioner etc).
 
@@ -173,6 +173,6 @@ There is no dev-preview phase.
 
 ## Infrastructure Needed
 
-* vsphere-csi-driver GitHub repository (forked from upstream).
-* vsphere-csi-driver-operator GitHub repository.
-* vsphere-csi-driver and vsphere-csi-driver-operator images.
+* vmware-vsphere-csi-driver GitHub repository (forked from upstream).
+* vmware-vsphere-csi-driver-operator GitHub repository.
+* vmware-vsphere-csi-driver and vmware-vsphere-csi-driver-operator images.

--- a/enhancements/storage/csi-vsphere-operator.md
+++ b/enhancements/storage/csi-vsphere-operator.md
@@ -106,8 +106,11 @@ Most of the steps outlined above is common to all CSI driver operator and vSpher
 
 There are certain aspects of driver which require special handling:
 
-1. When vSphere CSI operator starts, using credentials provided by cluster-storage-operator, it will first verifiy vCenter version and HW version of VMs. If vCenter version is not 6.7u3 or greater and HW version is not 15 or greater on all VMs - it will set `vSphereOperatorDisabled: true` and stop further processing.
+1. When vSphere CSI operator starts, using credentials provided by cluster-storage-operator, it will first verifiy vCenter version and HW version of VMs. If vCenter version is not 6.7u3 or greater and HW version is not 15 or greater on all VMs - it will set `vSphereOperatorDisabled: true` and stop further processing. If additional VMs are added later into the cluster and they do not have HW version 15 or greater, Operator will mark itself as `degraded` and nodes which don't have right HW version will have annotation `vsphere.driver.status.csi.openshift.io: degraded` added to them.
+
+
 2. Since VMWare will ship its own vSphere CSI driver operator via OLM, it should be possible to disable default cluster-storage-operator managed operator(i.e this operator). Currently we are planning to let user set `ManagementState: Removed` in `ClusterCSIDriver` CR, which will cause operand to be removed(i.e the CSI driver) but operator will still be running. This will allow user to use external vSphere CSI operatrs.
+
 3. If a storage policy is found in `vsphere.Platform` then a StorageClass will be created for vSphere CSI driver. If no storage policy is configured in `vsphere.Platform` then no storageClass will be created and it is expected that admin will manually create a storageClass after cluster installation.
 
 

--- a/enhancements/storage/csi-vsphere-operator.md
+++ b/enhancements/storage/csi-vsphere-operator.md
@@ -68,8 +68,92 @@ To solve this following alternatives were considered:
 
 #### StoragePolicy configuration
 
-Currently while deploying Openshift a user can configure datastore used by OCP via install-config.yaml. vSphere CSI driver however can't use datastore directly and must be configured with vSphere storage policy. This can be done by an optional field in `Infrastructure` type of installer and if populated vsphere CSI driver operator will create storageClass with selected vSphere storage policy.
+Currently while deploying Openshift a user can configure datastore used by OCP via install-config.yaml. vSphere CSI driver however can't use datastore directly and must be configured with vSphere storage policy. This can be done by an optional field in `vsphere.Platform` type of installer and if populated vsphere CSI driver operator will create storageClass with selected vSphere storage policy.
+
+One downside of having storage policy as an optional field is - when in-tree vSphere driver is removed from Kubernetes then without a default storage policy
+configured in OCP - such clusters will come up with no default storageClass installed and will require manual creation of storageClasses.
 
 ### Deployment strategy
 
 vSphere CSI driver operator will be deployed by [cluster-storage-operator](https://github.com/openshift/cluster-storage-operator/)
+
+#### Operator deployment via cluster-storage-operator
+
+The cluster-storage-operator will deploy all the resources necessary for creating the vSphere CSI driver operator.
+
+1. vSphere CSI driver operator will be deployed in namespace `openshift-cluster-csi-drivers`.
+2. A service account will be created for running the operator.
+3. The operator will get RBAC rules necessary for running the operator and its operand (i.e the actual vSphere CSI driver).
+4. A deployment will be created for starting the operator and will be managed by cluster-storage-operator.
+5. A instance of `ClusterCSIDriver` will be created to faciliate managment of driver operator.  `ClusterCSIDriver` is already defined in - https://github.com/openshift/api/blob/master/operator/v1/types_csi_cluster_driver.go but needs to be expanded to include vSphere CSI driver.
+6. cluster-storage-operator will create required cloud-credentials for talking with vCenter API.
+
+#### Driver deployment via vsphere-csi-driver-operator.
+
+The operator itself will be responsible for running the driver and all the required sidecars (attacher, provisioner etc).
+
+1. The operator will create namespace `openshift-cluster-csi-drivers` to deploy the driver and sidecars.
+2. A service account will be created for running the driver.
+3. The operator will create RBAC rules necessary for running the driver and sidecars.
+4. A deployment will be created and managed by operator to handle control-plane sidecars and controller-plane driver deployment with controller-side of CSI services.
+5. A DaemonSet will be created and managed by operator to run node side of driver operations.
+6. A `CSIDriver` object will be created to expose driver features to control-plane.
+7. The driver operator will use and expose cloud-credentials created by cluster-storage-operator.
+
+Most of the steps outlined above is common to all CSI driver operator and vSphere CSI driver is not unique among those aspects.
+
+#### Additional consideration for vSphere
+
+There are certain aspects of driver which require special handling:
+
+1. When vSphere CSI operator starts, using credentials provided by cluster-storage-operator, it will first verifiy vCenter version and HW version of VMs. If vCenter version is not 6.7u3 or greater and HW version is not 15 or greater on all VMs - it will set `vSphereOperatorDisabled: true` and stop further processing.
+2. Since VMWare will ship its own vSphere CSI driver operator via OLM, it should be possible to disable default cluster-storage-operator managed operator(i.e this operator). Currently we are planning to let user set `ManagementState: Removed` in `ClusterCSIDriver` CR, which will cause operand to be removed(i.e the CSI driver) but operator will still be running. This will allow user to use external vSphere CSI operatrs.
+3. If a storage policy is found in `vsphere.Platform` then a StorageClass will be created for vSphere CSI driver. If no storage policy is configured in `vsphere.Platform` then no storageClass will be created and it is expected that admin will manually create a storageClass after cluster installation.
+
+
+#### Disabling the operator
+
+#### API
+
+The operator will use https://github.com/openshift/api/blob/master/operator/v1/types_csi_cluster_driver.go for operator configuration and managment.
+
+### User stories
+
+#### Story 1
+
+### Implementation Details/Notes/Constraints
+
+### Risks and Mitigations
+
+* We don't yet know state of vSphere CSI driver. We need to start running e2e tests with vSphere driver as early as possible, so as we can determine how stable it is.
+* We have some concerns about datastore not being supported in storageClass anymore. This means that in future when in-tree driver is removed, clusters without storagePolicy will become unupgradable.
+
+### Test plan
+
+* We plan to enable e2e for vSphere CSI driver.
+
+### Graduation Criteria
+
+There is no dev-preview phase.
+
+##### Tech Preview
+
+##### Tech Preview -> GA
+
+##### Removing a deprecated feature
+
+### Upgrade / Downgrade Strategy
+
+### Version Skew Strategy
+
+## Implementation History
+
+## Drawbacks
+
+## Alternatives
+
+## Infrastructure Needed
+
+* vsphere-csi-driver GitHub repository (forked from upstream).
+* vsphere-csi-driver-operator GitHub repository.
+* vsphere-csi-driver and vsphere-csi-driver-operator images.

--- a/enhancements/subscription-content/subscription-injection.md
+++ b/enhancements/subscription-content/subscription-injection.md
@@ -1,0 +1,663 @@
+---
+title: subscription-injection-operator
+authors:
+  - "@adambkaplan"
+reviewers:
+  - "@gabemontero"
+  - "@coreydaley"
+  - "@otaviof"
+approvers:
+  - "@bparees"
+  - "@derekwaynecarr"
+creation-date: 2020-06-25
+last-updated: 2020-09-16
+status: implementable
+see-also:
+  - /enhancements/cluster-scope-secret-volumes/csi-driver-host-injections.md
+  - https://github.com/openshift/enhancements/pull/384
+replaces: []
+superseded-by: []
+---
+
+# Subscription Injection Operator
+
+## Release Signoff Checklist
+
+- [x] Enhancement is `implementable`
+- [x] Design details are appropriately documented from clear requirements
+- [x] Test plan is defined
+- [x] Graduation criteria for dev preview, tech preview, GA
+- [ ] User-facing documentation is created in
+      [openshift-docs](https://github.com/openshift/openshift-docs/)
+
+## Summary
+
+This enhancement will allow any workload to access RHEL subscription content via a pod annotation.
+
+## Motivation
+
+Containers can download RHEL content if their hosts have subscriptions attached. In 3.x, all nodes
+were assumed to be RHEL 7 nodes that were subscribed individually. The information needed to access
+subscription content (entitlement keys and `redhat.repo` configurations) was symbolically linked
+into the running container at a well-known location that yum/dnf could find. This capability
+existed in our patch of Docker, and was carried over into Red Hat’s container toolchain used on
+OpenShift 4 (cri-o, podman, buildah, etc.).
+
+In OpenShift 4 the preferred operating system (RHCOS) is not capable of attaching subscriptions
+individually. To access subscription content, containers must be provided entitlement keys and
+optionally `redhat.repo` configurations via other means. Enabling this capability needs to be
+simple and straightforward.
+
+### Goals
+
+1. Inject entitlement keys, such as the Simple Content Access key, into a pod spec.
+2. Allow overrides of the `redhat.repo` configuration for containers that need to connect to
+   Satellite.
+3. Define APIs and conventions that allow cluster admins to add the required information to a
+   cluster (entitlement keys and `redhat.repo` configurations).
+4. Allow multiple entitlements to be made available to a container.
+
+### Non-Goals
+
+1. Automatically install entitlement keys and `redhat.repo` configurations onto a subscribed
+   cluster.
+2. Automatically rotate entitlement keys and update `redhat.repo` configurations on a subscribed
+   cluster.
+3. Dynamically add additional entitlement keys to running containers by mounting an additional
+   `Secret`
+
+## Proposal
+
+### User Stories
+
+#### Add RHEL content to running containers
+
+As a developer or application administrator
+I want access to RHEL subscription content in my containers
+So that I can install RHEL content within my container via `yum install`
+
+#### Access RHEL content from a Satellite instance
+
+As a developer using OpenShift 
+I want to be able to access RHEL content from my Satellite instance
+So that I download RHEL content from my Satellite instances instead of the Red Hat CDN.
+
+### Implementation Details/Notes/Constraints [optional]
+
+#### Installation and Setup
+
+When the `subscription-injection-operator` is installed, it creates the subscription `Bundle` and
+`ClusterBundle` custom resource definition. The operator deployment creates sample YAML files
+which helps admins get started with default, cluster-wide and namespace-scoped subscription
+bundles:
+
+```yaml
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: subscription-cluster-bundle-example
+spec:
+  targetResource:
+    apiVersion: subscription.openshift.io/v1
+    kind: ClusterBundle
+  title: Cluster-wide subscription bundle example
+  description: | 
+    An example of a subscription bundle that can be injected into any workload that has the
+    `subscription.openshift.io/inject-cluster-bundle: cluster` annotation in its pod spec, and
+    whose service account has the `edit` or `admin` role.
+  yaml: |
+    apiVersion: subscription.openshift.io/v1
+    kind: ClusterBundle
+    metadata:
+      name: cluster
+    spec:
+      aggregateToClusterRoles:
+      - edit
+      - admin
+      entitlements:
+      - name: etc-pki-entitlement
+        namespace: openshift-config
+```
+
+```yaml
+apiVersion: console.openshift.io/v1
+kind: ConsoleYAMLSample
+metadata:
+  name: subscription-namespaced-bundle-example
+spec:
+  title: Namespaced subscription bundle example
+  description: |
+    An example of a subscription bundle that can be injected into any workload in the bundle's
+    namespace that has the `subscription.openshift.io/inject-bundle: subscription` annotation in
+    its pod spec.
+  targetResource:
+    apiVersion: subscription.openshift.io/v1
+    kind: Bundle
+  yaml: |
+    apiVersion: subscription.openshift.io/v1
+    kind: Bundle
+    metadata:
+      name: subscription
+    spec:
+      entitlements:
+      - name: etc-pki-entitlement
+```
+
+The `entitlements` object is a reference to the `Secrets` which contain the entitlement keys for
+the cluster's subscription. The cluster administrator is responsible for obtaining the entitlement
+keys and adding them to the cluster. Administrators can refer to existing guidance on how to obtain
+this information.
+
+The API specs will also include a `yumRepositories` field, which allows for a list of `ConfigMaps`
+containing `.repo` configuration files that allow an entitlement to be downloaded from a Red Hat
+Satellite instance.
+
+#### Subscription Cluster Bundle Controller
+
+When a `ClusterBundle` object is created, the Subscription Bundle Controller (a new controller)
+will perform the necessary actions to make the bundle available to cluster workloads. This consists
+of the following:
+
+1. Verify that the referenced `entitlements` and optional `yumRepositories` resources exist.
+2. Create the ProjectedResource CSI driver `Shares` for the `entitlements` and (optional)
+  `yumRepositories` as declared in the Projected Resource CSI Driver proposal.
+3. Create a `ClusterRole` associated with the bundle, which grants `get`, `watch`, and `list`
+   permissions to the associated `Shares` and the `ClusterBundle` object.
+4. Aggregate the cluster role to the provided list of system roles.
+5. Add owner references to the generated `ClusterRole` and shares. This ensures the dependent
+   objects are deleted when the `ClusterBundle` is deleted.
+
+When a `ClusterBundle` object is updated, changes to the referenced `entitlements` and
+`yumRepositories` are propagated to the associated `Share` objects. Likewise, changes to aggregated
+cluster roles should be propagated to the associated `ClusterRole`. Non-terminated pods which have
+the `ClusterBundle` injected are not altered - only new pods which inject the `ClusterBundle` will
+receive the updated mounts for `entitlements` and `yumRepositories`.
+
+When a `ClusterBundle` object is deleted, the owner references above will ensure deletion of the
+associated objects. Non-terminated pods which inject the deleted `ClusterBundle` are not impacted.
+New pods which inject the deleted `ClusterBundle` will be rejected by an admission webhook (see 
+below).
+
+#### Subscription Bundle Controller
+
+`Bundle` objects to not require any special actions on creation. The escalation risk of a service
+account listing the names of `Secrets` and `ConfigMaps` it does not have permission to list/read is
+minimal. Consumers of `Bundle` objects are generally assumed to have the ability to create `Pods`
+within a namespace, and therefore will likely have read/list permissions on `Secrets` and
+`ConfigMaps`.
+
+When a `Bundle` object is updated, new pods which inject the `Bundle` will mount in the updated
+`entitlements` and `yumRepositories` references. Non-terminated pods will continue to run with
+the previously referenced `entitlements` and `yumRepositories`. Changes to underlying `Secrets`
+and `ConfigMaps` should be handled by respective volume mount controllers.
+
+When a `Bundle` object is deleted, non-terminated pods which inject the deleted `Bundle` will
+continue to run with the previously injected `entitlements` and `yumRepositories` mounts. New pods
+which inject the deleted `Bundle` will be rejected by an admission webhook (see below).
+
+#### Subscription Bundle Injection
+
+Developers can inject subscription bundles localized to their namespace by adding the
+`subscription.openshift.io/inject-bundle` annotation to a pod template spec. The value of the
+annotation is a comma-separated list of bundles to inject. Any workload controller which
+ultimately creates a `Pod` will be supported. For example, to inject multiple bundles into a
+`Deployment`, use the following YAML:
+
+```yaml
+kind: Deployment
+apiVersion: v1
+metadata:
+  name: my-rhel-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: "rhel-deployment"
+  template:
+    metadata:
+      annotations:
+        "subscription.openshift.io/inject-bundle": mybundle,otherbundle
+      labels:
+        app: "rhel-deployment"
+    spec:
+      containers:
+      - name: run
+        image: "registry.redhat.io/ubi8/ubi:latest"
+        ...
+```
+
+The Subscription Injection mutating admission webhook will listen to all pod creation API calls.
+The webhook will do the following:
+
+1. Look for the `subscription.openshift.io/inject-bundle` annotation
+2. Read the `Bundles` with names matching the annotation CSV values that exist in the pod's
+   namespace. Reject admission if any of the bundles do not exist.
+3. Read the `Bundles` in the namespace which have the
+   `subscription.openshift.io/always-inject: "true"` label. Check these bundles against the allow/
+   deny annotations on the pod.
+4. Verify that the `Secrets` referenced in `entitlements` across eligible bundles do not contain
+   overlapping keys. Reject admission if the secrets contain overlapping keys.
+5. Add a `ProjectedVolume` in the pod for the `entitlements` referenced in the bundle.
+6. Mount the entitlements volume into `/run/secrets/etc-pki-entitlement` for each container in
+   the pod, including init and ephemeral containers.
+7. [optional] Verify that the `ConfigMaps` referenced in `yumRepositories` across eligible bundles
+   do not contain overlapping keys. Reject admission if the `ConfigMaps` contain overlapping keys.
+8. [optional] Add a `ProjectedVolume` in the pod for the `yumRepositories` referenced in the bundle
+   which sources data via the projected resource CSI driver.
+9. [optional] Mount the yum repos volume into `/run/secrets` for each container in the pod,
+   including init and ephemeral containers.
+10. Record the generation of the injected bundles by adding or updating the generations JSON value
+    in the `subscription.openshift.io/bundle-generations` annotation.
+
+#### Cluster Subscription Bundle Injection
+
+Developers can inject cluster-wide subscription bundles by adding the
+`subscription.openshift.io/inject-cluster-bundle` annotation to a pod template spec. Any workload
+controller which ultimately creates a `Pod` will be supported. For example, to inject a
+subscription into a `Deployment`, use the following YAML:
+
+```yaml
+kind: Deployment
+apiVersion: v1
+metadata:
+  name: my-rhel-deployment
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: "rhel-deployment"
+  template:
+    metadata:
+      annotations:
+        "subscription.openshift.io/inject-cluster-bundle": cluster
+      labels:
+        app: "rhel-deployment"
+    spec:
+      containers:
+      - name: run
+        image: "registry.redhat.io/ubi8/ubi:latest"
+        ...
+```
+
+The Subscription Injection mutating admission webhook will watch all newly created pods. The
+webhook will do the following:
+
+1. Look for the `subscription.openshift.io/inject-cluster-bundle` annotation.
+2. Read the `ClusterBundles` with names matching the annotation values. Reject admission if the
+   bundle does not exist.
+3. Read the `ClusterBundles` with the `subscription.openshift.io/always-inject: "true"` label.
+   Check these bundles against the allow/deny annotations on the pod.
+4. Conduct a subject access review for the referenced `ClusterBundles` against the pod service
+   account. Return an error if the pod service account does not have `get` access to the
+   `ClusterBundle`.
+5. Verify that the `Secrets` referenced in `entitlements` across eligible `ClusterBundles` do not 
+   contain overlapping keys. Reject admission if the secrets contain overlapping keys.
+6. Add `Volumes` in the pod for the `entitlements` referenced in the bundle which sources data via
+   the projected resource CSI driver.
+7. Mount the `entitlements` volumes into `/run/secrets/etc-pki-entitlement` for each container in
+   the pod, including init and ephemeral containers.
+8. [optional] Verify that the `ConfigMaps` referenced in `yumRepositories` across elibilbe
+   `ClusterBundles` do not contain overlapping keys. Reject admission if the `ConfigMaps` contain
+   overlapping keys.
+9. [optional] Add `Volumes` in the pod for the `yumRepositories` referenced in the bundle which
+   sources data via the projected resource CSI driver.
+10. [optional] Mount the `yumRepositories` volumes into `/run/secrets` for each container in the pod,
+    including init and ephemeral containers.
+11. Record the generation of the injected bundles by adding or updating the generations JSON value
+    in the `subscription.openshift.io/bundle-generations` annotation.
+
+#### Subscription Injection Mutating Admission Webhook
+
+Per upstream docs, the mutating admission webhook will need to register itself with the cluster and
+run as a service in its own namespace [1]. The operator installing the Subscription Injection
+webhook will need to do the following:
+
+1. Create a `Deployment` that runs the webhook in a highly available mode.
+2. Create a `Service` to expose the webhook pods, with generated TLS cert/key pairs.
+3. Create a `ConfigMap` where the service serving CA can be injected.
+4. Create a `MutatingWebhookConfiguration` that fires the webhook for all created pods.
+5. When the service serving CA in item 3 is injected or updated, the operator needs to update the
+   caBundle provided to the webook configuration in 4.
+
+[1]
+https://kubernetes.io/blog/2019/03/21/a-guide-to-kubernetes-admission-controllers/#mutating-webhook-configuration
+
+#### Bundle API
+
+```yaml
+kind: ClusterBundle
+apiVersion: subscription.openshift.io/v1alpha1
+metadata:
+  name: <name>
+  ... # standard metadata, cluster-scoped so no namespace
+  labels:
+    # Special label to auto inject a ClusterBundle
+    subscription.openshift.io/always-inject: "true"
+spec:
+  aggregateToClusterRoles: # cluster roles which the ClusterBundle RBAC should aggregate to.
+  - admin
+  - edit
+  entitlements:
+  - name: <secret name with entitlement keys>
+    namespace: <namespace containing the secret>
+  yumRepositories:
+  - name: <configMap name with yum repo definition>
+    namespace: <namespace for the yum repo definition>
+status:
+  conditions:
+  - type: Invalid
+    status: "False" # standard k8s conditions, should obey the "abnormal-true" convention
+  - ... # additional informational conditions
+  clusterRole: <name>-subscription-bundle # clusterRole is cluster-scoped
+  shares:
+  - name: <name>-subscription-entitlement # shares are cluster-scoped
+  - name: <name>-subscription-yumRepository
+```
+
+```yaml
+kind: Bundle
+apiVersion: subscription.openshift.io/v1alpha1
+metadata:
+  name: <name>
+  namespace: <namespace>
+  ... # standard metadata
+  labels:
+    # Special label to auto-inject a Bundle in a namespace
+    subscription.openshift.io/always-inject: "true"
+spec:
+  entitlements:
+  - name: <secret name with entitlement keys>
+    namespace: <namespace containing the secret>
+  yumRepositories:
+  - name: <configMap name with yum repo definition>
+    namespace: <namespace for the yum repo definition>
+status:
+  conditions:
+  - type: Invalid
+    status: "False" # standard k8s conditions, should obey the "abnormal-true" convention
+  - ... # additional informational conditions
+```
+
+#### Pod Annotations and Mounts
+
+Injecting a namespace-scoped `Bundle`:
+
+```yaml
+kind: Pod
+apiVersion: core/v1
+metadata:
+  annotations:
+    # Inject namespace-scoped bundles
+    "subscription.openshift.io/inject-bundle": local,driver
+    # Record the generation of the injected bundles
+    "subscription.openshift.io/bundle-generations": |
+      {
+        "bundles": {
+          "local": 2,
+          "driver": 3
+        }
+      }
+spec:
+  containers:
+  - name: main
+    ...
+    volumeMounts:
+    # Mount yum-repos.d configs in /run/secrets
+    - name: yum-repo
+      mountPath: /run/secrets
+    # Mount entitlements in /run/secrets/etc-pki-entitlement
+    - name: etc-pki-entitlement
+      mountPath: /run/secrets/etc-pki-entitlement
+  ...
+  volumes:
+  # yumRepositories are consolidated into a single volume
+  # Projected volumes with no key/path mappings require that all refereneced keys are unique
+  - name: yum-repo
+    projected:
+      sources:
+      - configMap:
+          name: local-repo
+      - configMap:
+          name: driver-repo
+  # Entitlement keys are likewise consolidated into a single volume
+  # Projected volumes with no key/path mappings require that all referenced keys are unique
+  - name: etc-pki-entitlement
+    projected:
+      sources:
+      - secret:
+          name: local-entitlement
+      - secret:
+          name: driver-entitlement
+```
+
+Injecting a cluster-scoped `ClusterBundle`:
+
+```yaml
+kind: Pod
+apiVersion: core/v1
+metadata:
+  annotations:
+    # Inject cluster-wide bundles
+    "subscription.openshift.io/inject-cluster-bundle": cluster,extra
+    # Record the generation of the injected bundles
+    "subscription.openshift.io/bundle-generations": |
+      {
+        "clusterBundles": {
+          "cluster": 1,
+          "extra": 4
+        }
+      }
+spec:
+  containers:
+  - name: main
+    ...
+    volumeMounts:
+    # Mount yum-repos.d configs in /run/secrets
+    - name: yum-repo
+      mountPath: /run/secrets
+    # Mount entitlements in /run/secrets/etc-pki-entitlement
+    - name: etc-pki-entitlement
+      mountPath: /run/secrets/etc-pki-entitlement
+  ...
+  volumes:
+  # yumRepositories are consolidated into a single volume
+  # Projected volumes with no key/path mappings require that all refereneced keys are unique
+  - name: yum-repo
+    csi:
+      driver: projected-resource.storage.openshift.io
+      volumeAttributes:
+        sources:
+        - share:
+            name: cluster-repo
+        - share:
+            name: extra-repo
+  # Entitlement keys are likewise consolidated into a single volume
+  # Projected volumes with no key/path mappings require that all referenced keys are unique
+  - name: etc-pki-entitlement
+    csi:
+      driver: projected-resource.storage.openshift.io
+      volumeAttributes:
+        sources:
+        - share:
+            name: local-entitlement
+        - share:
+            name: driver-entitlement
+```
+
+Allow/deny lists for bundles that are always injected. Note that if none of these annotations are
+present, all available auto-injected bundles are added to the pod:
+
+```yaml
+kind: Pod
+apiVersion: core/v1
+metadata:
+  annotations:
+    # Allow some bundles in the namespace, deny all others
+    subscription.openshift.io/allow-bundles: "bundle-A,bundle-B"
+    # Deny some bundles in the namespace, but allow others
+    subscription.openshift.io/deny-bundles: "bundle-B,bundle-C"
+    # Deny all bundles in the namespace
+    subscription.openshift.io/deny-bundles: "*"
+    # Allow some cluster bundles, but deny others
+    subscription.openshift.io/allow-cluster-bundles: "cluster-bundle-A"
+    # Deny some cluster bundles, but allow others
+    subscription.openshift.io/deny-cluster-bundles: "cluster-bundle-A,cluster-bundle-B"
+    # Deny all cluster bundles
+    subscription.openshift.io/deny-cluster-bundles: "*"
+  ...
+```
+
+### Risks and Mitigations
+
+**Risk:** Entitlement keys can leak outside of the `openshift-config` namespace to unauthorized
+workloads.
+
+_Mitigation:_ Access to the entitlement keys is gated by the cluster role generated for the
+projected resource shares associated with the bundle. Cluster admins are responsible for either
+
+1. Creating a `ClusterRoleBinding` for the service accounts that need access to the entitlement, OR
+2. Declaring cluster roles to aggregate the `ClusterBundle` to via the `aggregateToClusterRoles`
+   array, OR
+3. Configuring the operator to aggregate the generated `ClusterRole` to appropriate system roles by
+   default.
+
+**Risk:** Shares and cluster roles are orphaned if the subscription `ClusterBundle` is deleted.
+
+_Mitigation:_ Owner references are used to ensure proper cleanup. Note that `ClusterBundle` is
+cluster-scoped, so it can create owner references on any object.
+
+**Risk:** Containers run with outdated entitlement keys if they are rotated
+
+_Mitigation:_ When an entitlement key is rotated, the secret containing the original key(s) should
+be directly updated with the new entitlement key. This would be treated as a content change by the
+the respective volume mount controller (kubelet for `Bundle`, projected resource csi driver for
+`ClusterBundle`). Updating a `Bundle` or `ClusterBundle` by changing the referenced `entitlements`
+and `yumRepositories` should be clearly discouraged in the documentation.
+
+## Design Details
+
+### Test Plan
+
+This feature set can be tested as follows:
+
+1. Download an OpenShift entitlement key set from the customer portal, and add it to the
+   `openshift-config` namespace as the `etc-pki-entitlement` `Secret`.
+2. Create a `ClusterBundle` object 
+2. Run a pod with the `"subscription.openshift.io/inject-cluster-bundle": cluster` annotation, and
+   a UBI8 container which performs a `yum install` of a RHEL package that requires a subscription.
+
+### Graduation Criteria
+
+This feature will likely require Dev Preview, Tech Preview, and GA maturity levels.
+
+#### Feature Roadmap
+
+1. `Bundle` supporting a single bundle injected into a workload within the same namespace, allowing
+   one entitlement secret and one yum.repo configuration.
+2. `Bundle` supporting multiple `entitlements` and `yumRepositories`.
+3. Allow multiple `Bundles` to be injected into a workload within the same namespace.
+4. Allow a `Bundle` to be automatically injected into a workload within a namespace.
+5. `ClusterBundle` supporting a single bundle injected into a workload, allowing one entitlement
+   secret and one yum.repo configuration.
+6. `ClusterBundle` supporting multiple `entitlements` and `yumRepositories`.
+7. Allow multiple `ClusterBundles` to be injected into a workload.
+8. Allow auto-injection of `ClusterBundles` into all workloads. 
+
+#### Dev Preview
+
+- Bundle APIs at `v1alpha1`.
+- Initial Dev preview release of just the `Bundle` object API and webhook.
+- Subsequent dev preview release of `ClusterBundle` with dependency on the projected resource CSI
+  driver (dev preview).
+
+##### Dev Preview -> Tech Preview
+
+- Projected resource CSI driver reaches tech preview state.
+- APIs reach `v1beta1`
+- Clear documentation on how to enable subscription injection across the cluster
+- Initial scale testing
+- Gather feedback for namespace-restricted subscription bundles
+- Release as a tech preview OLM operator
+
+##### Tech Preview -> GA
+
+- All APIs reach `v1` stability
+- Projected resource CSI driver reaches GA
+- Security audit for these components and the projected resource CSI driver
+- Scale testing (with potential mitigations like `HorizontalPodAutoscalers`)
+- Disruption testing (with potential mitigations like `PodDisruptionBudgets`)
+
+### Upgrade / Downgrade Strategy
+
+Upgrades and downgrades will be handled via OLM. Each released version will specify:
+
+- Minimum supported version of the projected resource CSI driver
+- Minimum supported kube version of the cluster.
+
+### Removal Strategy
+
+As an OLM operator, removing the Subscription Injection operator will not remove the associated
+custom resource definitions. As a result, existing `Bundle` and `ClusterBundle` objects will remain
+on the cluster and the associated injected volumes will remain intact.
+
+### Version Skew Strategy
+
+- OLM addresses cluster version skew via the minimum supported Kubernetes version attribute as well
+  as minimum supported `GroupVersionKind` for dependent CRDs.
+- Version skew for the bundle controllers can be addressed via leader election.
+- Version skew for the admission webhook can be addressed via standard `Deployment` rollouts.
+  Temporary version skew for the admission webhook is acceptable.
+
+### Open Questions
+
+1. Is allowing an admission webhook which can read all `Secrets` and `ConfigMaps` acceptable?
+   The assumption is yes - admission webhooks in general require a high level of privilege.
+2. When a `Bundle`/`ClusterBundle` is updated or deleted, how can we evict pods in a way that is scalable?
+   We won't evict pods - new pods receive updated mount specs, existing pods aren't changed.
+
+## Implementation History
+
+- 2020-06-25: Initial proposal
+- 2020-09-16: Implementable version
+
+## Drawbacks
+
+- Since this is being delivered via OLM, customers will need to opt into capabilities that they may
+  expect by default.
+- Users will have to specify on a per-workload basis which subscriptions should be added,
+  increasing toil.
+- Cluster admins need to manually obtain their entitlement keys, add them to the cluster, and
+  configure appropriate `ClusterBundle` objects.
+
+## Alternatives
+
+### Document what we have
+
+Today, any UBI/RHEL-based container can access subscription content if the entitlement keys are
+mounted into `/run/secrets/etc-pki-entitlement`. Clusters which access content via Satellite will
+also need `redhat.repo` configurations mounted into `/run/secrets`. This is not well documented in
+OpenShift. Customers will need to obtain entitlement keys and update their pods on their own.
+Likewise, Satellite users will need to obtain a `redhat.repo` configurations and mount it into
+their pods.
+
+Builds have their own docs since they use a separate mechanism to add Secrets and ConfigMaps into
+the build context.
+
+### Mount subscription bundles through the node
+
+As a work-around, customers can create a MachineConfig that adds the same entitlement keys to
+/etc/pki/entitlement/ on every node [1]. CRI-O and buildah are configured by default to mount these
+entitlement keys into all running containers.
+
+There are two main downsides to this approach:
+
+1. Nodes need to be restarted when the entitlement keys are added or updated/rotated.
+2. Only one set of entitlements can be shared per node. Mutli-tenancy isn't feasible unless tenant
+   workloads are tied to specific nodes.
+
+[1] https://access.redhat.com/solutions/4908771
+
+## Infrastructure Needed [optional]
+
+To test this via CI, our CI clusters would need to obtain entitlement keys. The template used to
+test this feature would need to add the entitlement keys after the cluster has been installed.

--- a/this-week/2020-11-06.md
+++ b/this-week/2020-11-06.md
@@ -1,0 +1,87 @@
+# This Week in Enhancements - 2020-11-6
+
+## Merged Enhancements
+
+*&lt;PR ID&gt;: (activity this week / total activity) summary*
+
+There were 6 Merged pull requests:
+
+- [352](https://github.com/openshift/enhancements/pull/352): (1/13) storage: Rework CSI driver installation to CVO / cluster-storage-operator (jsafrane)
+
+  > We want certain CSI drivers such as AWS, GCE, Cinder, Azure and vSphere to be installable on OpenShift, so as:
+  > * They can be used along-side in-tree drivers and when upstream enables migration flag for these volume types, their   replacement CSI drivers can take over and none of the storage features get affected. 
+  > * OpenShift provides native storage provided by underlying cloud out of the box after installation for the clouds that   don't have in-tree volume plugins in Kubernetes.
+
+- [389](https://github.com/openshift/enhancements/pull/389): (0/62) subscription-content: Subscription Injection Operator (adambkaplan)
+
+  > This enhancement will allow any workload to access RHEL subscription content via a pod annotation.
+
+- [493](https://github.com/openshift/enhancements/pull/493): (4/65) storage: Add vsphere csi operator enhancement (gnufied)
+
+  > This enhancement proposes deployment of vSphere CSI driver on Openshift as a default component.
+
+
+### Merged Minor Updates
+
+- [505](https://github.com/openshift/enhancements/pull/505): (1/1) general: Add mention of operator CR to operator dev doc (marun)
+- [521](https://github.com/openshift/enhancements/pull/521): (0/0) storage: Update CSI repo names (jsafrane)
+
+## Closed Enhancements
+
+*&lt;PR ID&gt;: (activity this week / total activity) summary*
+
+There was 1 Closed pull requests:
+
+- [231](https://github.com/openshift/enhancements/pull/231): (0/8) cluster-logging: A first stab at container log throttling enhancement proposal (syedriko)
+
+## New Enhancements
+
+*&lt;PR ID&gt;: (activity this week / total activity) summary*
+
+There were 4 New pull requests:
+
+- [522](https://github.com/openshift/enhancements/pull/522): (8/8) olm: Update OLM managed operator metrics enhancement (awgreene)
+
+  > The primary purpose of this enhancement is to enable [Operator-Lifecycle-Manager (OLM)](https://github.com/operator-framework/operator-lifecycle-manager) managed operators to easily integrate with the [Prometheus Operator](https://github.com/coreos/prometheus-operator) on OpenShift and Vanilla Kubernetes Clusters. Additionally, this enhancement focuses on enabling OLM managed operators to record metrics with the [OpenShift Monitoring](https://github.com/openshift/cluster-monitoring-operator) Prometheus Operator present on all OpenShift Clusters.
+  >
+  > OLM will support tight integration with the Prometheus Operator by allowing operator authors to package `ServiceMonitor` and `PrometheusRule` objects within their [Operator Bundle](https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md) and will manage these resources alongside the lifecycle of the operator.
+  >
+  > OLM will also define how an operator author can surface the following information in the [OpenShift Console UI](https://github.com/openshift/console) when a Cluster Admin is installing an operator, which will be needed when integrating with with OpenShift's Monitoring services:
+  >
+  >- A suggested namespace that the operator should be deployed to. 
+  >- That the operator exposes metrics that should be scraped by the OpenShift Monitoring Prometheus instance present on all OpenShift clusters.
+
+- [524](https://github.com/openshift/enhancements/pull/524): (0/0) network: New method for providing configurable  self-hosted LB/DNS/VIP for on-prem (yboaron)
+
+  > In the current implementation,  the self-hosted DNS/LB stack runs under the MCO umbrella by default in all on-prem platforms and there's no option to configure it.  Some customers with high production needs usually have their own external Load Balancing and DNS resolution. In addition, there are cases in which some traffic used to provide these self-hosted services is disallowed in the customer's network.
+  > 
+  > The outcome of such scenarios is that cluster's resources are spent on providing unused services and generating traffic against certain customers network design.
+  >
+  > This enhancement suggests a new method for providing the self-hosted stack.   *Note:* as per the OCP plan to move API and Ingress to K8S SLB, this direction should be investigated deeper after MetalLb will be integrated.
+
+- [525](https://github.com/openshift/enhancements/pull/525): (0/0) machine-config: WIP: Add FCCT support in MC proposal (LorbusChris)
+
+  > Proposal to add support for Fedora CoreOS Config (FCC) in the Config field of MachineConfig (MC) resources.
+  >
+  > The Config field is of the `runtime.RawExtension` type and can therefore contain arbitrary data. The machine-config-operator (MCO) currently supports parsing the RawExtension contents for Ignition spec v2.2, v3.0 and v3.1 configuration. Internally, the configuration from all MachineConfig objects are translated to spec v3.1 and merged into a rendered MC which represents the canonical state the MCO enforces. FCC is more human friendly to write and read than Ignition config, and can be transpiled to Ignition spec v3.1 config safely with the Fedora CoreOS Config Transpiler (FCCT). Support for FCCs can be added by adding the FCCT parser to the RawExtension processing chain.
+
+- [527](https://github.com/openshift/enhancements/pull/527): (6/6) installer: enhancement/installer: check OpenStack versions (EmilienM)
+
+  > OpenShift can only be installed on supported versions of OpenStack. While the [Support Matrix](https://access.redhat.com/articles/4679401) is well documented, the OpenShift installer doesn't check which version of OpenStack is running before attempting an operation (e.g. installation).  Running OpenShift over an unsupported version of OpenStack is problematic and can lead to unstable infrastructure. To avoid that, it is proposed to programmatically verify the version of OpenStack is supported otherwise stop and fail.
+
+
+## Active Enhancements
+
+*&lt;PR ID&gt;: (activity this week / total activity) summary*
+
+There were 9 Active pull requests:
+
+- [482](https://github.com/openshift/enhancements/pull/482): (27/183) general: Add single-node-developer Cluster Profile (rkukura)
+- [463](https://github.com/openshift/enhancements/pull/463): (26/482) machine-api: Describing steps to support out-of-tree providers (Danil-Grigorev)
+- [507](https://github.com/openshift/enhancements/pull/507): (14/116) authentication: new/auth: allow users to manage their tokens (stlaz)
+- [508](https://github.com/openshift/enhancements/pull/508): (14/22) console: Add Customize Developer Catalog Categories enhancement (jerolimov)
+- [486](https://github.com/openshift/enhancements/pull/486): (5/62) local-storage: Adds proposal for auto partitioning in LSO (rohan47)
+- [520](https://github.com/openshift/enhancements/pull/520): (4/4) network: Static IP Addresses from DHCP (cybertron)
+- [473](https://github.com/openshift/enhancements/pull/473): (4/184) network: Enable IPsec support in OVNKubernetes (markdgray)
+- [504](https://github.com/openshift/enhancements/pull/504): (2/76) general: single-node production deployments (dhellmann)
+- [357](https://github.com/openshift/enhancements/pull/357): (1/141) accelerators: Supporting out-of-tree drivers on OpenShift (zvonkok)


### PR DESCRIPTION
This change reflects the updated implementation of the upgrade process of WMCO.
Previous upgrade design states that WMCO makes use of `maxUnavailable` field in
the Windows MachineSet to determine deletion of nodes with version annotation
mismatch. As this field is not available in the MachineSet spec, the updated
design makes use of `maxUnhealthy` count defined internally by WMCO. This count
ensures that we have only maxUnhealthy number of nodes in Not Ready state
during upgrades